### PR TITLE
Re-adding Help block

### DIFF
--- a/thugs_bot.py
+++ b/thugs_bot.py
@@ -29,6 +29,25 @@ CREATE TABLE PARTICIPATION(
 );
  """
 
+@bot.message_handler(commands=['help'])
+def help_message(message):
+    resp = """
+    Interact with Bounty system with the following commands:\n
+    \n
+    **User Commands**:\n
+    - `/leaderboard` |  Show the Leaderboard\n
+    - `/onthejob {bounty}` | Register for an active Bounty\n
+    - `/highfive {@User}` | Send a share to a User\n"""
+
+    if message.from_user.username in admin_usernames:
+        resp += """
+        **Admin Commands**:\n
+        - `/grant {@User} {shares}` | Grant shares\n
+        - `/addbounty {name} {share_value} {time_limit}` | Add a new Bounty\n
+        - `/endbounty {name}` | End a Bounty\n"""
+
+    bot.reply_to(message, resp)
+
 @bot.message_handler(commands=['register'])
 def register(message):
     if(True): #if(message.from_user.id in admin_usernames):


### PR DESCRIPTION
Checks whether the caller is in the admin_usernames array and provide relevant info.

This should be changed to UIDs eventually, but that's beyond the scope of this PR.